### PR TITLE
fix: bypass overlay interception with JavaScript clicks in CI

### DIFF
--- a/tests/basic/test_mobile_box.py
+++ b/tests/basic/test_mobile_box.py
@@ -81,6 +81,7 @@ class TestPopupOnMobile:
             '.MuiIconButton-root[aria-label="close"], .leaflet-popup-close-button'
         )
         expect(close_button).to_be_visible()
+        close_button.scroll_into_view_if_needed()
         close_button.click(force=True)
 
         # Verify dialog is closed

--- a/tests/basic/test_mobile_box.py
+++ b/tests/basic/test_mobile_box.py
@@ -32,14 +32,10 @@ class TestPopupOnMobile:
         # Navigate to the page (device emulation already configured by mobile_page fixture)
         mobile_page.goto(BASE_URL, wait_until="domcontentloaded")
 
-        # Remove webpack overlay if it exists (flaky on CI)
-        mobile_page.evaluate(
-            "() => document.getElementById('webpack-dev-server-client-overlay')?.remove()"
-        )
-
         # Click first marker to expand cluster
+        # Use force=True to bypass webpack overlay that may intercept clicks on CI
         first_marker = mobile_page.locator(".leaflet-marker-icon").first
-        first_marker.click()
+        first_marker.click(force=True)
 
         # Wait for markers to appear (should be 2 after expansion)
         markers = mobile_page.locator(".leaflet-marker-icon")
@@ -85,7 +81,7 @@ class TestPopupOnMobile:
             '.MuiIconButton-root[aria-label="close"], .leaflet-popup-close-button'
         )
         expect(close_button).to_be_visible()
-        close_button.click()
+        close_button.click(force=True)
 
         # Verify dialog is closed
         expect(dialog_content).not_to_be_visible()

--- a/tests/basic/test_mobile_box.py
+++ b/tests/basic/test_mobile_box.py
@@ -33,9 +33,9 @@ class TestPopupOnMobile:
         mobile_page.goto(BASE_URL, wait_until="domcontentloaded")
 
         # Click first marker to expand cluster
-        # Use force=True to bypass webpack overlay that may intercept clicks on CI
+        # Use JavaScript click to bypass webpack overlay that may intercept clicks on CI
         first_marker = mobile_page.locator(".leaflet-marker-icon").first
-        first_marker.click(force=True)
+        first_marker.evaluate("el => el.click()")
 
         # Wait for markers to appear (should be 2 after expansion)
         markers = mobile_page.locator(".leaflet-marker-icon")
@@ -81,8 +81,8 @@ class TestPopupOnMobile:
             '.MuiIconButton-root[aria-label="close"], .leaflet-popup-close-button'
         )
         expect(close_button).to_be_visible()
-        close_button.scroll_into_view_if_needed()
-        close_button.click(force=True)
+        # Use JavaScript click to bypass any overlay issues on CI
+        close_button.evaluate("el => el.click()")
 
         # Verify dialog is closed
         expect(dialog_content).not_to_be_visible()

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -140,29 +140,19 @@ def verify_problem_form(page: Page) -> None:
     Args:
         page: Playwright page object
     """
-    # Click "report a problem" link
-    # Use force=True to bypass webpack overlay that may intercept clicks on CI
-    # Scroll into view first since force=True skips scrolling
+    # Click "report a problem" link using JavaScript to bypass any overlay issues
+    # force=True still clicks at coordinates which can be intercepted on CI
     report_link = page.locator("text=report a problem")
     expect(report_link).to_be_visible()
     report_link.scroll_into_view_if_needed()
-    # Brief wait for scroll animation to complete on small viewports
-    page.wait_for_timeout(100)
-    report_link.click(force=True)
+    # Use dispatchEvent to trigger click directly on the element (cannot be intercepted)
+    report_link.evaluate("el => el.click()")
 
     # Wait for form to appear inside the popup
     # Scope to popup to avoid matching the filter form
     popup = page.locator(".leaflet-popup-content, .MuiDialogContent-root")
     form = popup.locator("form")
-
-    # Retry click if form doesn't appear (handles race conditions on small viewports)
-    try:
-        expect(form).to_be_visible(timeout=2000)
-    except AssertionError:
-        report_link.scroll_into_view_if_needed()
-        page.wait_for_timeout(100)
-        report_link.click(force=True)
-        expect(form).to_be_visible(timeout=3000)
+    expect(form).to_be_visible()
 
     # Verify dropdown has expected options
     dropdown = form.locator("select")
@@ -201,9 +191,10 @@ def verify_problem_form(page: Page) -> None:
 
         # Submit the form
         # TODO: Remove input[type="submit"] after goodmap-frontend unifies - new version uses button
+        # Use JavaScript click to bypass webpack overlay that may intercept clicks on CI
         submit_button = form.locator('input[type="submit"], button:has-text("Submit")').first
         expect(submit_button).to_be_visible()
-        submit_button.click()
+        submit_button.evaluate("el => el.click()")
 
     # Verify API response
     response = response_info.value

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -141,16 +141,10 @@ def verify_problem_form(page: Page) -> None:
         page: Playwright page object
     """
     # Click "report a problem" link
-    # Forcibly remove webpack overlay that may intercept clicks (defense in depth)
-    page.evaluate(
-        """() => {
-            const overlay = document.getElementById('webpack-dev-server-client-overlay');
-            if (overlay) overlay.remove();
-        }"""
-    )
+    # Use force=True to bypass webpack overlay that may intercept clicks on CI
     report_link = page.locator("text=report a problem")
     expect(report_link).to_be_visible()
-    report_link.click()
+    report_link.click(force=True)
 
     # Wait for form to appear inside the popup
     # Scope to popup to avoid matching the filter form


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved stability of mobile and form-verification tests by switching to JavaScript-triggered clicks and scroll-into-view interactions to bypass transient overlays in CI, preserving marker expansion and dialog flows.
  * Added contextual comments clarifying the overlay-bypass strategy and interaction adjustments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->