### PR TITLE
fix: remove webpack overlay and add touch support to mobile tests

### DIFF
--- a/tests/basic/test_location_buttons.py
+++ b/tests/basic/test_location_buttons.py
@@ -217,14 +217,10 @@ class TestLocationButtonsMobile:
         """
         mobile_page.goto(BASE_URL, wait_until="domcontentloaded")
 
-        # Remove webpack overlay that may intercept clicks on CI
-        mobile_page.evaluate(
-            "document.getElementById('webpack-dev-server-client-overlay')?.remove()"
-        )
-
         # Tap the list view button
+        # Use force=True to bypass webpack overlay that may intercept clicks on CI
         list_view_button = mobile_page.locator("#listViewButton")
-        list_view_button.click()
+        list_view_button.click(force=True)
 
         # Check tooltip appears with disabled message
         tooltip = mobile_page.locator('[role="tooltip"]')
@@ -239,11 +235,6 @@ class TestLocationButtonsMobile:
         """
         mobile_page.goto(BASE_URL, wait_until="domcontentloaded")
 
-        # Remove webpack overlay that may intercept clicks on CI
-        mobile_page.evaluate(
-            "document.getElementById('webpack-dev-server-client-overlay')?.remove()"
-        )
-
         buttons = [
             ("#listViewButton", "List View"),
             ('[aria-label*="Location target"]', "Location"),
@@ -252,8 +243,9 @@ class TestLocationButtonsMobile:
 
         for selector, _name in buttons:
             # Tap the button
+            # Use force=True to bypass webpack overlay that may intercept clicks on CI
             button = mobile_page.locator(selector)
-            button.click()
+            button.click(force=True)
 
             # Check tooltip appears
             tooltip = mobile_page.locator('[role="tooltip"]')
@@ -261,5 +253,5 @@ class TestLocationButtonsMobile:
             expect(tooltip).to_contain_text("Location services are disabled")
 
             # Click elsewhere to dismiss tooltip and wait for it to disappear
-            mobile_page.locator("body").click(position={"x": 10, "y": 10})
+            mobile_page.locator("body").click(position={"x": 10, "y": 10}, force=True)
             expect(tooltip).not_to_be_visible(timeout=2000)

--- a/tests/basic/test_location_buttons.py
+++ b/tests/basic/test_location_buttons.py
@@ -218,8 +218,9 @@ class TestLocationButtonsMobile:
         mobile_page.goto(BASE_URL, wait_until="domcontentloaded")
 
         # Tap the list view button
+        # Use JavaScript click to bypass webpack overlay that may intercept clicks on CI
         list_view_button = mobile_page.locator("#listViewButton")
-        list_view_button.click()
+        list_view_button.evaluate("el => el.click()")
 
         # Check tooltip appears with disabled message
         tooltip = mobile_page.locator('[role="tooltip"]')
@@ -242,8 +243,9 @@ class TestLocationButtonsMobile:
 
         for selector, _name in buttons:
             # Tap the button
+            # Use JavaScript click to bypass webpack overlay that may intercept clicks on CI
             button = mobile_page.locator(selector)
-            button.click()
+            button.evaluate("el => el.click()")
 
             # Check tooltip appears
             tooltip = mobile_page.locator('[role="tooltip"]')
@@ -251,5 +253,6 @@ class TestLocationButtonsMobile:
             expect(tooltip).to_contain_text("Location services are disabled")
 
             # Click elsewhere to dismiss tooltip and wait for it to disappear
-            mobile_page.locator("body").click(position={"x": 10, "y": 10})
+            # Use JavaScript click to bypass any overlay issues
+            mobile_page.evaluate("document.body.click()")
             expect(tooltip).not_to_be_visible(timeout=2000)

--- a/tests/basic/test_location_buttons.py
+++ b/tests/basic/test_location_buttons.py
@@ -217,11 +217,14 @@ class TestLocationButtonsMobile:
         """
         mobile_page.goto(BASE_URL, wait_until="domcontentloaded")
 
+        # Remove webpack overlay that may intercept clicks on CI
+        mobile_page.evaluate(
+            "document.getElementById('webpack-dev-server-client-overlay')?.remove()"
+        )
+
         # Tap the list view button
-        # Use force=True to bypass webpack overlay that may intercept clicks on CI
-        # Use tap() instead of click() to trigger touch events needed for mobile tooltips
         list_view_button = mobile_page.locator("#listViewButton")
-        list_view_button.tap(force=True)
+        list_view_button.click()
 
         # Check tooltip appears with disabled message
         tooltip = mobile_page.locator('[role="tooltip"]')
@@ -236,6 +239,11 @@ class TestLocationButtonsMobile:
         """
         mobile_page.goto(BASE_URL, wait_until="domcontentloaded")
 
+        # Remove webpack overlay that may intercept clicks on CI
+        mobile_page.evaluate(
+            "document.getElementById('webpack-dev-server-client-overlay')?.remove()"
+        )
+
         buttons = [
             ("#listViewButton", "List View"),
             ('[aria-label*="Location target"]', "Location"),
@@ -244,16 +252,14 @@ class TestLocationButtonsMobile:
 
         for selector, _name in buttons:
             # Tap the button
-            # Use force=True to bypass webpack overlay that may intercept clicks on CI
-            # Use tap() instead of click() to trigger touch events needed for mobile tooltips
             button = mobile_page.locator(selector)
-            button.tap(force=True)
+            button.click()
 
             # Check tooltip appears
             tooltip = mobile_page.locator('[role="tooltip"]')
             expect(tooltip).to_be_visible(timeout=2000)
             expect(tooltip).to_contain_text("Location services are disabled")
 
-            # Tap elsewhere to dismiss tooltip and wait for it to disappear
-            mobile_page.locator("body").tap(position={"x": 10, "y": 10}, force=True)
+            # Click elsewhere to dismiss tooltip and wait for it to disappear
+            mobile_page.locator("body").click(position={"x": 10, "y": 10})
             expect(tooltip).not_to_be_visible(timeout=2000)

--- a/tests/basic/test_location_buttons.py
+++ b/tests/basic/test_location_buttons.py
@@ -218,9 +218,10 @@ class TestLocationButtonsMobile:
         mobile_page.goto(BASE_URL, wait_until="domcontentloaded")
 
         # Tap the list view button
-        # Use JavaScript click to bypass webpack overlay that may intercept clicks on CI
+        # Use force=True to bypass webpack overlay that may intercept clicks on CI
+        # Use tap() instead of click() to trigger touch events needed for mobile tooltips
         list_view_button = mobile_page.locator("#listViewButton")
-        list_view_button.evaluate("el => el.click()")
+        list_view_button.tap(force=True)
 
         # Check tooltip appears with disabled message
         tooltip = mobile_page.locator('[role="tooltip"]')
@@ -243,16 +244,16 @@ class TestLocationButtonsMobile:
 
         for selector, _name in buttons:
             # Tap the button
-            # Use JavaScript click to bypass webpack overlay that may intercept clicks on CI
+            # Use force=True to bypass webpack overlay that may intercept clicks on CI
+            # Use tap() instead of click() to trigger touch events needed for mobile tooltips
             button = mobile_page.locator(selector)
-            button.evaluate("el => el.click()")
+            button.tap(force=True)
 
             # Check tooltip appears
             tooltip = mobile_page.locator('[role="tooltip"]')
             expect(tooltip).to_be_visible(timeout=2000)
             expect(tooltip).to_contain_text("Location services are disabled")
 
-            # Click elsewhere to dismiss tooltip and wait for it to disappear
-            # Use JavaScript click to bypass any overlay issues
-            mobile_page.evaluate("document.body.click()")
+            # Tap elsewhere to dismiss tooltip and wait for it to disappear
+            mobile_page.locator("body").tap(position={"x": 10, "y": 10}, force=True)
             expect(tooltip).not_to_be_visible(timeout=2000)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -262,9 +262,11 @@ def mobile_page(browser, webpack_script: str, request) -> Generator[Page, None, 
             f"Unknown device_name={device_name}. Expected one of: {list(MOBILE_DEVICES)}"
         ) from e
 
-    # Create a new context with mobile user agent
+    # Create a new context with mobile user agent and touch support
     context = browser.new_context(
-        viewport=device_config["viewport"], user_agent=device_config["user_agent"]
+        viewport=device_config["viewport"],
+        user_agent=device_config["user_agent"],
+        has_touch=True,
     )
 
     # Create a page from this context


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Prevented CI overlay from blocking interactions by removing the dev-server overlay before taps/clicks.
  * Ensured mobile tests simulate touch input by enabling touch support in the test context.
  * No changes to test assertions or logic—only interaction handling to improve CI reliability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->