### PR TITLE
fix: improve E2E test stability with proper element waits and video recording

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -200,6 +200,15 @@ jobs:
         retention-days: 1
         if-no-files-found: ignore
 
+    - name: Upload test videos on failure
+      if: failure()
+      uses: actions/upload-artifact@v4
+      with:
+        name: test-failure-videos
+        path: e2e-tests/test-results/**/*.webm
+        retention-days: 7
+        if-no-files-found: ignore
+
     - name: Stop frontend server
       if: always()
       run: |

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -103,6 +103,15 @@ jobs:
         set -o pipefail
         make e2e-tests | tee /tmp/e2e-tests-output.txt
 
+    - name: Upload test videos on failure
+      if: failure()
+      uses: actions/upload-artifact@v4
+      with:
+        name: test-failure-videos
+        path: e2e-tests/test-results/**/*.webm
+        retention-days: 7
+        if-no-files-found: ignore
+
     - name: Stop backend for e2e tests
       if: always()
       shell: bash {0}
@@ -198,15 +207,6 @@ jobs:
           /tmp/pr-sha.txt
           /tmp/stress-test-perf.json
         retention-days: 1
-        if-no-files-found: ignore
-
-    - name: Upload test videos on failure
-      if: failure()
-      uses: actions/upload-artifact@v4
-      with:
-        name: test-failure-videos
-        path: e2e-tests/test-results/**/*.webm
-        retention-days: 7
         if-no-files-found: ignore
 
     - name: Stop frontend server

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -73,7 +73,7 @@ jobs:
     - name: Start frontend server
       working-directory: goodmap-frontend
       run: |
-        make serve &
+        make serve-prod &
         FRONTEND_PID=$!
         echo $FRONTEND_PID > /tmp/frontend.pid
         disown $FRONTEND_PID

--- a/e2e_stress_test_config.yml
+++ b/e2e_stress_test_config.yml
@@ -24,4 +24,4 @@ FEATURE_FLAGS:
 
 
 #GOODMAP_FRONTEND_LIB_URL: "https://cdn.jsdelivr.net/npm/@problematy/goodmap@0.4.4"
-GOODMAP_FRONTEND_LIB_URL: "http://localhost:8080/index.js"
+GOODMAP_FRONTEND_LIB_URL: "http://localhost:8080/index.min.js"

--- a/e2e_test_config.yml
+++ b/e2e_test_config.yml
@@ -27,4 +27,4 @@ FEATURE_FLAGS:
   SHOW_SUGGEST_NEW_POINT_BUTTON: True
 
 
-GOODMAP_FRONTEND_LIB_URL: "http://localhost:8080/index.min.js"
+GOODMAP_FRONTEND_LIB_URL: "http://localhost:8080/index.js"

--- a/e2e_test_config.yml
+++ b/e2e_test_config.yml
@@ -27,4 +27,4 @@ FEATURE_FLAGS:
   SHOW_SUGGEST_NEW_POINT_BUTTON: True
 
 
-GOODMAP_FRONTEND_LIB_URL: "http://localhost:8080/index.js"
+GOODMAP_FRONTEND_LIB_URL: "http://localhost:8080/index.min.js"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,9 @@ python_functions = "test_*"
 # Playwright-specific settings
 base_url = "http://localhost:5000"
 # Browser/headed/slowmo should be passed via CLI: --browser=chromium --headed --slowmo=100
+# Video recording: retain-on-failure keeps videos only for failed tests
+# Videos are saved to test-results/ directory
+addopts = "--video=retain-on-failure --output=test-results"
 
 [tool.ruff]
 line-length = 100

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,6 @@ python_functions = "test_*"
 base_url = "http://localhost:5000"
 # Browser/headed/slowmo should be passed via CLI: --browser=chromium --headed --slowmo=100
 # Video recording: retain-on-failure keeps videos only for failed tests
-# Videos are saved to test-results/ directory
 addopts = "--video=retain-on-failure --output=test-results"
 
 [tool.ruff]

--- a/tests/basic/test_left_panel.py
+++ b/tests/basic/test_left_panel.py
@@ -155,8 +155,9 @@ class TestLeftPanelMobile:
         """
         mobile_page.goto(BASE_URL, wait_until="domcontentloaded")
 
-        # Wait for page to load
-        mobile_page.wait_for_load_state("networkidle")
+        # Wait for toggle button to be visible (indicates page is ready)
+        toggle_button = mobile_page.locator('button[aria-label="Toggle left panel"]')
+        toggle_button.wait_for(state="visible")
 
         # Filter dialog should not be visible by default on mobile
         filter_dialog = mobile_page.locator('[role="dialog"]')

--- a/tests/basic/test_left_panel.py
+++ b/tests/basic/test_left_panel.py
@@ -235,6 +235,7 @@ class TestLeftPanelMobile:
 
         # Open the panel
         toggle_button = mobile_page.locator('button[aria-label="Toggle left panel"]')
+        toggle_button.wait_for(state="visible")
         toggle_button.click()
 
         # Wait for panel to open
@@ -265,6 +266,7 @@ class TestLeftPanelMobile:
 
         # Open the panel
         toggle_button = mobile_page.locator('button[aria-label="Toggle left panel"]')
+        toggle_button.wait_for(state="visible")
         toggle_button.click()
 
         # Wait for panel to open and content to load
@@ -307,6 +309,7 @@ class TestLeftPanelTablet:
 
         # Open the panel
         toggle_button = page.locator('button[aria-label="Toggle left panel"]')
+        toggle_button.wait_for(state="visible")
         toggle_button.click()
 
         # Wait for panel to open and content to load

--- a/tests/basic/test_left_panel.py
+++ b/tests/basic/test_left_panel.py
@@ -1,0 +1,387 @@
+"""
+Left Panel (Filter Sidebar) Tests
+
+Tests the left panel (filter sidebar) functionality across different viewport sizes:
+- Desktop (≥992px): Panel displays inline with fixed 220px width
+- Tablet (768px-992px): Panel is offcanvas overlay, 80vw width
+- Mobile (<768px): Panel is offcanvas overlay, 80vw width
+
+These tests verify:
+- Panel visibility and positioning
+- Panel scrolling when content overflows
+- No page-level scrollbar (only panel scrolls)
+- Close button styling and functionality on mobile/tablet
+- Filter text is not truncated
+"""
+
+import pytest
+from playwright.sync_api import Page, expect
+
+from tests.conftest import ALL_MOBILE_DEVICES, BASE_URL, MOBILE_DEVICES
+
+
+class TestLeftPanelDesktop:
+    """Test suite for left panel on desktop viewport (≥992px)"""
+
+    def test_panel_is_visible_inline_on_desktop(self, page: Page):
+        """
+        On desktop, the left panel should be visible inline (not as overlay)
+        without needing to click a toggle button.
+        """
+        page.set_viewport_size({"width": 1200, "height": 800})
+        page.goto(BASE_URL, wait_until="domcontentloaded")
+
+        # Wait for filter categories to load
+        page.wait_for_selector("#filter-form", timeout=10000)
+
+        # Panel should be visible
+        panel = page.locator("#left-panel")
+        expect(panel).to_be_visible()
+
+        # Panel should have position: relative on desktop (inline, not overlay)
+        position = panel.evaluate("el => getComputedStyle(el).position")
+        assert position == "relative", f"Expected position: relative, got: {position}"
+
+    def test_panel_has_fixed_width_on_desktop(self, page: Page):
+        """
+        On desktop, the panel should have a fixed 220px width.
+        """
+        page.set_viewport_size({"width": 1200, "height": 800})
+        page.goto(BASE_URL, wait_until="domcontentloaded")
+
+        page.wait_for_selector("#filter-form", timeout=10000)
+
+        panel = page.locator("#left-panel")
+        width = panel.evaluate("el => el.clientWidth")
+
+        # Width should be 220px (allow small tolerance for borders/scrollbar)
+        assert 215 <= width <= 230, f"Expected panel width ~220px, got: {width}px"
+
+    def test_no_page_scrollbar_on_desktop(self, page: Page):
+        """
+        The page/body should have overflow: hidden to prevent page-level scrollbar.
+        Only the filter panel should scroll, not the whole page.
+        """
+        page.set_viewport_size({"width": 1200, "height": 800})
+        page.goto(BASE_URL, wait_until="domcontentloaded")
+
+        page.wait_for_selector("#filter-form", timeout=10000)
+
+        # Check body overflow is hidden
+        body_overflow = page.evaluate("() => getComputedStyle(document.body).overflow")
+        assert body_overflow == "hidden", f"Expected body overflow: hidden, got: {body_overflow}"
+
+        # Check that body doesn't have vertical scroll
+        has_scroll = page.evaluate(
+            "() => document.body.scrollHeight > document.body.clientHeight"
+        )
+        assert not has_scroll, "Page should not have vertical scroll"
+
+    def test_panel_content_scrolls_on_desktop(self, page: Page):
+        """
+        When panel content exceeds the available height, the panel body
+        should be scrollable to access all filter categories.
+        """
+        # Use smaller viewport height to ensure content overflows
+        page.set_viewport_size({"width": 1200, "height": 600})
+        page.goto(BASE_URL, wait_until="domcontentloaded")
+
+        page.wait_for_selector("#filter-form", timeout=10000)
+
+        # Get panel body
+        panel_body = page.locator("#left-panel .offcanvas-body")
+
+        # Check if content overflows (scrollHeight > clientHeight)
+        scroll_info = panel_body.evaluate(
+            """el => ({
+                clientHeight: el.clientHeight,
+                scrollHeight: el.scrollHeight,
+                hasOverflow: el.scrollHeight > el.clientHeight
+            })"""
+        )
+
+        # If there's overflow, verify scrolling works
+        if scroll_info["hasOverflow"]:
+            # Get initial scroll position
+            initial_scroll = panel_body.evaluate("el => el.scrollTop")
+
+            # Scroll down
+            panel_body.evaluate("el => el.scrollBy(0, 200)")
+
+            # Verify scroll position changed
+            new_scroll = panel_body.evaluate("el => el.scrollTop")
+            assert new_scroll > initial_scroll, "Panel body should be scrollable"
+
+    def test_all_filter_categories_accessible_on_desktop(self, page: Page):
+        """
+        All filter categories (types, gender, condition, type_of_place, transparency)
+        should be accessible, either visible or reachable by scrolling.
+        """
+        page.set_viewport_size({"width": 1200, "height": 600})
+        page.goto(BASE_URL, wait_until="domcontentloaded")
+
+        page.wait_for_selector("#filter-form", timeout=10000)
+
+        # Scroll to bottom of panel to ensure all content is accessible
+        panel_body = page.locator("#left-panel .offcanvas-body")
+        panel_body.evaluate("el => el.scrollTop = el.scrollHeight")
+
+        # Check that transparency category (typically last) is visible after scrolling
+        # Look for the category header text
+        transparency_visible = page.evaluate(
+            """() => {
+                const panel = document.querySelector('#left-panel .offcanvas-body');
+                const text = panel.textContent.toLowerCase();
+                return text.includes('transparency') || text.includes('high') || text.includes('low');
+            }"""
+        )
+        assert transparency_visible, "Transparency category should be accessible after scrolling"
+
+
+class TestLeftPanelMobile:
+    """Test suite for left panel on mobile viewport (<992px)"""
+
+    @pytest.mark.parametrize("device_name", ALL_MOBILE_DEVICES)
+    def test_panel_hidden_by_default_on_mobile(self, mobile_page: Page, device_name: str):
+        """
+        On mobile, the left panel should be hidden by default (offcanvas).
+        """
+        mobile_page.goto(BASE_URL, wait_until="domcontentloaded")
+
+        # Wait for page to load
+        mobile_page.wait_for_load_state("networkidle")
+
+        # Panel should not be visually active (offcanvas is hidden)
+        panel = mobile_page.locator("#left-panel")
+
+        # Check that panel doesn't have 'show' class (Bootstrap offcanvas)
+        has_show_class = panel.evaluate("el => el.classList.contains('show')")
+        assert not has_show_class, "Panel should not have 'show' class by default on mobile"
+
+    @pytest.mark.parametrize("device_name", ["iphone-6"])
+    def test_panel_opens_on_toggle_click(self, mobile_page: Page, device_name: str):
+        """
+        Clicking the toggle button should open the left panel as an offcanvas overlay.
+        """
+        mobile_page.goto(BASE_URL, wait_until="domcontentloaded")
+
+        # Find and click the toggle button
+        toggle_button = mobile_page.locator('button[aria-label="Toggle left panel"]')
+        expect(toggle_button).to_be_visible()
+        toggle_button.click()
+
+        # Wait for panel to be visible
+        panel = mobile_page.locator("#left-panel")
+        expect(panel).to_be_visible(timeout=5000)
+
+        # Panel should have 'show' class when open
+        has_show_class = panel.evaluate("el => el.classList.contains('show')")
+        assert has_show_class, "Panel should have 'show' class when open"
+
+    @pytest.mark.parametrize("device_name", ["iphone-6"])
+    def test_close_button_visible_on_mobile(self, mobile_page: Page, device_name: str):
+        """
+        On mobile, the panel should have a visible close button (X).
+        """
+        mobile_page.goto(BASE_URL, wait_until="domcontentloaded")
+
+        # Open the panel
+        toggle_button = mobile_page.locator('button[aria-label="Toggle left panel"]')
+        toggle_button.click()
+
+        # Wait for panel to open
+        mobile_page.wait_for_selector("#left-panel.show", timeout=5000)
+
+        # Close button should be visible
+        close_button = mobile_page.locator("#left-panel .btn-close")
+        expect(close_button).to_be_visible()
+
+    @pytest.mark.parametrize("device_name", ["iphone-6"])
+    def test_close_button_closes_panel(self, mobile_page: Page, device_name: str):
+        """
+        Clicking the close button should close the panel.
+        """
+        mobile_page.goto(BASE_URL, wait_until="domcontentloaded")
+
+        # Open the panel
+        toggle_button = mobile_page.locator('button[aria-label="Toggle left panel"]')
+        toggle_button.click()
+
+        # Wait for panel to open
+        mobile_page.wait_for_selector("#left-panel.show", timeout=5000)
+
+        # Click close button
+        close_button = mobile_page.locator("#left-panel .btn-close")
+        close_button.click()
+
+        # Wait for panel to close
+        mobile_page.wait_for_selector("#left-panel:not(.show)", timeout=5000)
+
+        # Verify panel is closed
+        panel = mobile_page.locator("#left-panel")
+        has_show_class = panel.evaluate("el => el.classList.contains('show')")
+        assert not has_show_class, "Panel should be closed after clicking close button"
+
+    @pytest.mark.parametrize("device_name", ["iphone-6"])
+    def test_panel_width_on_mobile(self, mobile_page: Page, device_name: str):
+        """
+        On mobile, the panel should be 80vw wide (80% of viewport width).
+        """
+        mobile_page.goto(BASE_URL, wait_until="domcontentloaded")
+
+        # Open the panel
+        toggle_button = mobile_page.locator('button[aria-label="Toggle left panel"]')
+        toggle_button.click()
+
+        # Wait for panel to open
+        mobile_page.wait_for_selector("#left-panel.show", timeout=5000)
+
+        # Get panel width and viewport width
+        widths = mobile_page.evaluate(
+            """() => ({
+                panelWidth: document.querySelector('#left-panel').clientWidth,
+                viewportWidth: window.innerWidth
+            })"""
+        )
+
+        expected_width = widths["viewportWidth"] * 0.8
+        actual_width = widths["panelWidth"]
+
+        # Allow 10% tolerance
+        assert (
+            expected_width * 0.9 <= actual_width <= expected_width * 1.1
+        ), f"Expected panel width ~{expected_width}px (80vw), got: {actual_width}px"
+
+    @pytest.mark.parametrize("device_name", ["iphone-6"])
+    def test_no_page_scrollbar_on_mobile(self, mobile_page: Page, device_name: str):
+        """
+        On mobile, there should be no page-level scrollbar.
+        """
+        mobile_page.goto(BASE_URL, wait_until="domcontentloaded")
+
+        # Open the panel
+        toggle_button = mobile_page.locator('button[aria-label="Toggle left panel"]')
+        toggle_button.click()
+
+        # Wait for panel to open and content to load
+        mobile_page.wait_for_selector("#left-panel.show", timeout=5000)
+        mobile_page.wait_for_selector("#filter-form", timeout=10000)
+
+        # Check body overflow is hidden
+        body_overflow = mobile_page.evaluate("() => getComputedStyle(document.body).overflow")
+        assert body_overflow == "hidden", f"Expected body overflow: hidden, got: {body_overflow}"
+
+
+class TestLeftPanelTablet:
+    """Test suite for left panel on tablet viewport (768px-992px)"""
+
+    def test_panel_is_offcanvas_on_tablet(self, page: Page):
+        """
+        On tablet (768px width), the panel should behave as offcanvas (like mobile).
+        """
+        page.set_viewport_size({"width": 768, "height": 1024})
+        page.goto(BASE_URL, wait_until="domcontentloaded")
+
+        # Panel should not be visible by default
+        panel = page.locator("#left-panel")
+
+        # Check that panel doesn't have 'show' class
+        has_show_class = panel.evaluate("el => el.classList.contains('show')")
+        assert not has_show_class, "Panel should be hidden by default on tablet"
+
+        # Toggle button should be visible
+        toggle_button = page.locator('button[aria-label="Toggle left panel"]')
+        expect(toggle_button).to_be_visible()
+
+    def test_filter_text_not_truncated_on_tablet(self, page: Page):
+        """
+        On tablet, all filter text should be fully visible without truncation.
+        Previously there was an issue where text like "type_of_place" was truncated.
+        """
+        page.set_viewport_size({"width": 768, "height": 1024})
+        page.goto(BASE_URL, wait_until="domcontentloaded")
+
+        # Open the panel
+        toggle_button = page.locator('button[aria-label="Toggle left panel"]')
+        toggle_button.click()
+
+        # Wait for panel to open and content to load
+        page.wait_for_selector("#left-panel.show", timeout=5000)
+        page.wait_for_selector("#filter-form", timeout=10000)
+
+        # Check that filter category headers are fully visible
+        # Look for specific text that was previously truncated
+        panel_text = page.evaluate(
+            "() => document.querySelector('#left-panel').textContent"
+        )
+
+        # These should be fully visible, not truncated
+        assert "type_of_place" in panel_text or "type of place" in panel_text.lower(), \
+            "type_of_place should be fully visible"
+        assert "parcel_machine" in panel_text or "parcel machine" in panel_text.lower(), \
+            "parcel_machine should be fully visible"
+
+
+class TestLeftPanelFilterHelpers:
+    """Test suite for filter option helper icons/tooltips"""
+
+    def test_small_bridge_filter_has_helper_tooltip(self, page: Page):
+        """
+        Verify that the 'small bridge' filter option in type_of_place category
+        has a helper icon that shows a tooltip on hover.
+        """
+        page.set_viewport_size({"width": 1200, "height": 800})
+        page.goto(BASE_URL, wait_until="domcontentloaded")
+
+        # Wait for filter form to load
+        page.wait_for_selector("#filter-form", timeout=10000)
+
+        # Find and hover over the help icon for small bridge
+        help_icon = page.get_by_label("Help: categories_options_help_small bridge")
+        expect(help_icon).to_be_visible()
+        help_icon.hover()
+
+        # Verify tooltip appears
+        tooltip = page.locator('[role="tooltip"]')
+        expect(tooltip).to_be_visible()
+        expect(tooltip).to_contain_text("categories_options_help_small bridge")
+
+
+class TestLeftPanelScrollbar:
+    """Test suite for panel scrollbar styling"""
+
+    def test_panel_has_custom_scrollbar_styling(self, page: Page):
+        """
+        The panel should have custom scrollbar styling (thin, semi-transparent).
+        """
+        page.set_viewport_size({"width": 1200, "height": 600})
+        page.goto(BASE_URL, wait_until="domcontentloaded")
+
+        page.wait_for_selector("#filter-form", timeout=10000)
+
+        # Check scrollbar-width CSS property
+        scrollbar_width = page.evaluate(
+            "() => getComputedStyle(document.querySelector('#left-panel')).scrollbarWidth"
+        )
+
+        # Firefox uses scrollbar-width property
+        # Chromium uses ::-webkit-scrollbar (can't easily check via JS)
+        # Just verify the property is set (may be empty string in Chromium)
+        # This test mainly verifies the CSS is being applied
+        assert scrollbar_width in ["thin", "auto", ""], \
+            f"Unexpected scrollbar-width value: {scrollbar_width}"
+
+    def test_offcanvas_body_has_overflow_auto(self, page: Page):
+        """
+        The offcanvas-body should have overflow-y: auto for scrolling.
+        """
+        page.set_viewport_size({"width": 1200, "height": 600})
+        page.goto(BASE_URL, wait_until="domcontentloaded")
+
+        page.wait_for_selector("#filter-form", timeout=10000)
+
+        overflow_y = page.evaluate(
+            "() => getComputedStyle(document.querySelector('#left-panel .offcanvas-body')).overflowY"
+        )
+
+        assert overflow_y == "auto", f"Expected overflow-y: auto, got: {overflow_y}"

--- a/tests/basic/test_location_buttons.py
+++ b/tests/basic/test_location_buttons.py
@@ -227,9 +227,6 @@ class TestLocationButtonsMobile:
         expect(tooltip).to_be_visible()
         expect(tooltip).to_contain_text("Location services are disabled")
 
-        # DEBUG: Keep tooltip visible for video capture - remove after debugging
-        mobile_page.wait_for_timeout(2000)
-
     @pytest.mark.parametrize("device_name", ALL_MOBILE_DEVICES)
     def test_all_buttons_show_tooltip_on_tap(self, mobile_page: Page, device_name: str):
         """
@@ -252,9 +249,9 @@ class TestLocationButtonsMobile:
 
             # Check tooltip appears
             tooltip = mobile_page.locator('[role="tooltip"]')
-            expect(tooltip).to_be_visible(timeout=200)
+            expect(tooltip).to_be_visible(timeout=2000)
             expect(tooltip).to_contain_text("Location services are disabled")
 
             # Click elsewhere to dismiss tooltip and wait for it to disappear
             mobile_page.locator("body").click(position={"x": 10, "y": 10})
-            expect(tooltip).not_to_be_visible(timeout=200)
+            expect(tooltip).not_to_be_visible(timeout=2000)

--- a/tests/basic/test_location_buttons.py
+++ b/tests/basic/test_location_buttons.py
@@ -217,14 +217,18 @@ class TestLocationButtonsMobile:
         """
         mobile_page.goto(BASE_URL, wait_until="domcontentloaded")
 
-        # Tap the list view button
+        # Tap the list view button (wait for it to be ready first)
         list_view_button = mobile_page.locator("#listViewButton")
+        list_view_button.wait_for(state="visible")
         list_view_button.click()
 
         # Check tooltip appears with disabled message
         tooltip = mobile_page.locator('[role="tooltip"]')
         expect(tooltip).to_be_visible()
         expect(tooltip).to_contain_text("Location services are disabled")
+
+        # DEBUG: Keep tooltip visible for video capture - remove after debugging
+        mobile_page.wait_for_timeout(2000)
 
     @pytest.mark.parametrize("device_name", ALL_MOBILE_DEVICES)
     def test_all_buttons_show_tooltip_on_tap(self, mobile_page: Page, device_name: str):
@@ -241,15 +245,16 @@ class TestLocationButtonsMobile:
         ]
 
         for selector, _name in buttons:
-            # Tap the button
+            # Tap the button (wait for it to be ready first)
             button = mobile_page.locator(selector)
+            button.wait_for(state="visible")
             button.click()
 
             # Check tooltip appears
             tooltip = mobile_page.locator('[role="tooltip"]')
-            expect(tooltip).to_be_visible(timeout=2000)
+            expect(tooltip).to_be_visible(timeout=200)
             expect(tooltip).to_contain_text("Location services are disabled")
 
             # Click elsewhere to dismiss tooltip and wait for it to disappear
             mobile_page.locator("body").click(position={"x": 10, "y": 10})
-            expect(tooltip).not_to_be_visible(timeout=2000)
+            expect(tooltip).not_to_be_visible(timeout=200)

--- a/tests/basic/test_location_buttons.py
+++ b/tests/basic/test_location_buttons.py
@@ -209,15 +209,15 @@ class TestLocationButtonsDesktopDisabledState:
 class TestLocationButtonsMobile:
     """Test suite for location buttons on mobile devices"""
 
-    @pytest.mark.parametrize("device_name", ALL_MOBILE_DEVICES)
-    def test_list_view_shows_tooltip_on_tap(self, mobile_page: Page, device_name: str):
+    @pytest.mark.parametrize("mobile_page", ALL_MOBILE_DEVICES, indirect=True)
+    def test_list_view_shows_tooltip_on_tap(self, mobile_page: Page):
         """
         Verify list view button shows tooltip immediately on tap
         when geolocation is not granted (mobile).
         """
         mobile_page.goto(BASE_URL, wait_until="domcontentloaded")
 
-        # Tap the list view button (wait for it to be ready first)
+        # Tap the list view button
         list_view_button = mobile_page.locator("#listViewButton")
         list_view_button.wait_for(state="visible")
         list_view_button.click()
@@ -227,8 +227,8 @@ class TestLocationButtonsMobile:
         expect(tooltip).to_be_visible()
         expect(tooltip).to_contain_text("Location services are disabled")
 
-    @pytest.mark.parametrize("device_name", ALL_MOBILE_DEVICES)
-    def test_all_buttons_show_tooltip_on_tap(self, mobile_page: Page, device_name: str):
+    @pytest.mark.parametrize("mobile_page", ALL_MOBILE_DEVICES, indirect=True)
+    def test_all_buttons_show_tooltip_on_tap(self, mobile_page: Page):
         """
         Verify all three location buttons show tooltips consistently on tap (mobile).
         Tests that enterTouchDelay=0 is working for all buttons.
@@ -242,7 +242,7 @@ class TestLocationButtonsMobile:
         ]
 
         for selector, _name in buttons:
-            # Tap the button (wait for it to be ready first)
+            # Tap the button
             button = mobile_page.locator(selector)
             button.wait_for(state="visible")
             button.click()

--- a/tests/basic/test_location_buttons.py
+++ b/tests/basic/test_location_buttons.py
@@ -218,9 +218,8 @@ class TestLocationButtonsMobile:
         mobile_page.goto(BASE_URL, wait_until="domcontentloaded")
 
         # Tap the list view button
-        # Use force=True to bypass webpack overlay that may intercept clicks on CI
         list_view_button = mobile_page.locator("#listViewButton")
-        list_view_button.click(force=True)
+        list_view_button.click()
 
         # Check tooltip appears with disabled message
         tooltip = mobile_page.locator('[role="tooltip"]')
@@ -243,9 +242,8 @@ class TestLocationButtonsMobile:
 
         for selector, _name in buttons:
             # Tap the button
-            # Use force=True to bypass webpack overlay that may intercept clicks on CI
             button = mobile_page.locator(selector)
-            button.click(force=True)
+            button.click()
 
             # Check tooltip appears
             tooltip = mobile_page.locator('[role="tooltip"]')
@@ -253,5 +251,5 @@ class TestLocationButtonsMobile:
             expect(tooltip).to_contain_text("Location services are disabled")
 
             # Click elsewhere to dismiss tooltip and wait for it to disappear
-            mobile_page.locator("body").click(position={"x": 10, "y": 10}, force=True)
+            mobile_page.locator("body").click(position={"x": 10, "y": 10})
             expect(tooltip).not_to_be_visible(timeout=2000)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -29,33 +29,12 @@ MAP_LOAD_TIMEOUT = 5000
 MARKER_LOAD_TIMEOUT = 5000
 TABLE_LOAD_TIMEOUT = 5000
 
-# Script to remove webpack-dev-server overlay that can intercept clicks
-# Uses CSS (when head exists) + MutationObserver (aggressive removal)
+# Script to remove webpack-dev-server overlay (fallback, overlay should be disabled via --no-client-overlay)
 WEBPACK_OVERLAY_REMOVAL_SCRIPT = """
-// Inject CSS to hide overlay - append to head if exists, otherwise documentElement
+// Hide webpack overlay if it appears (fallback safety)
 const style = document.createElement('style');
-style.textContent = `#webpack-dev-server-client-overlay {
-    display: none !important;
-    pointer-events: none !important;
-    visibility: hidden !important;
-}`;
+style.textContent = '#webpack-dev-server-client-overlay { display: none !important; }';
 (document.head || document.documentElement).appendChild(style);
-
-// Aggressive MutationObserver - remove overlay immediately when it appears
-const observer = new MutationObserver((mutations) => {
-    for (const mutation of mutations) {
-        for (const node of mutation.addedNodes) {
-            if (node.id === 'webpack-dev-server-client-overlay') {
-                node.remove();
-                return;
-            }
-        }
-    }
-    // Also check if it already exists
-    const overlay = document.getElementById('webpack-dev-server-client-overlay');
-    if (overlay) overlay.remove();
-});
-observer.observe(document.documentElement, { childList: true, subtree: true });
 """
 
 # Mobile device configurations for Playwright

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -262,11 +262,9 @@ def mobile_page(browser, webpack_script: str, request) -> Generator[Page, None, 
             f"Unknown device_name={device_name}. Expected one of: {list(MOBILE_DEVICES)}"
         ) from e
 
-    # Create a new context with mobile user agent and touch support
+    # Create a new context with mobile user agent
     context = browser.new_context(
-        viewport=device_config["viewport"],
-        user_agent=device_config["user_agent"],
-        has_touch=True,
+        viewport=device_config["viewport"], user_agent=device_config["user_agent"]
     )
 
     # Create a page from this context

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,7 +19,7 @@ import pytest
 from playwright.sync_api import BrowserContext, Page, Route
 
 # Constants
-WEBPACK_SCRIPT_URL = "http://localhost:8080/index.js"
+WEBPACK_SCRIPT_URL = "http://localhost:8080/index.min.js"
 CACHE_DIR = Path(".playwright-cache")
 CACHE_FILE = CACHE_DIR / "webpack-script.js"
 BASE_URL = "http://localhost:5000"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -285,10 +285,11 @@ def mobile_page(browser, webpack_script: str, request) -> Generator[Page, None, 
         # Set video size to match mobile viewport for clearer recordings
         record_video_size = device_config["viewport"]
 
-    # Create a new context with mobile user agent and optional video recording
+    # Create a new context with mobile user agent, touch support, and optional video recording
     context = browser.new_context(
         viewport=device_config["viewport"],
         user_agent=device_config["user_agent"],
+        has_touch=True,
         record_video_dir=record_video_dir,
         record_video_size=record_video_size,
     )


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive left-panel tests (desktop/tablet/mobile) and improved mobile interaction reliability by waiting for readiness before taps/clicks.
* **Chores**
  * E2E tests now use the minified frontend and per-test video recording is enabled with retain-on-failure.
* **CI**
  * Stabilized frontend startup with a short delay and added automatic upload of failure videos for easier debugging.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->